### PR TITLE
Added: areaColor prop for color overriding or gradients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 .DS_Store
 npm-debug.log*
+.idea

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ class MyComponent extends Component {
         data={data}
         includeZero={false} // Default: true
         areaOpacity={0} // Default: 0.3
+        areaColor={['red', 'white']} // Default: {color}
       />
     );
   }

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -34,6 +34,28 @@ class App extends React.Component {
           areaOpacity={0}
         />
 
+        <p>Random data with area color</p>
+        <SparkLine
+            animate
+            animationDuration={2000}
+            width={100}
+            height={30}
+            color="red"
+            data={data}
+            areaColor="orange"
+        />
+
+        <p>Random data with area gradient</p>
+        <SparkLine
+          animate
+          animationDuration={2000}
+          width={100}
+          height={30}
+          color="red"
+          data={data}
+          areaColor={['red', 'white']}
+        />
+
         <p>Single value (100)</p>
         <SparkLine
           animate

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -36,13 +36,13 @@ class App extends React.Component {
 
         <p>Random data with area color</p>
         <SparkLine
-            animate
-            animationDuration={2000}
-            width={100}
-            height={30}
-            color="red"
-            data={data}
-            areaColor="orange"
+          animate
+          animationDuration={2000}
+          width={100}
+          height={30}
+          color="red"
+          data={data}
+          areaColor="orange"
         />
 
         <p>Random data with area gradient</p>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,8 +30,8 @@ export class SparkLine extends React.Component<SparkLineProps, SparkLineState> {
     includeZero: PropTypes.bool,
     areaOpacity: PropTypes.number,
     areaColor: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.arrayOf(PropTypes.string),
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string),
     ]),
   };
 
@@ -165,27 +165,27 @@ export class SparkLine extends React.Component<SparkLineProps, SparkLineState> {
 
       // If areaColor is provided and it is an array, create a gradient
       if (areaColor && Array.isArray(areaColor)) {
-          // Set the gradient to be from the top to the bottom
-          const gradient = this.canvas
-              .createLinearGradient(0, 0, 0, height);
+        // Set the gradient to be from the top to the bottom
+        const gradient = this.canvas
+          .createLinearGradient(0, 0, 0, height);
 
-          // gradient.addColorStop() requires a number between 0 and 1 as the color stop
-          const stops = 1 / areaColor.length;
+        // gradient.addColorStop() requires a number between 0 and 1 as the color stop
+        const stops = 1 / areaColor.length;
 
-          // Add each of the colors to the gradient
-          areaColor.forEach((c: string, index: number) => {
-              const stop = stops * (index + 1);
-              gradient.addColorStop(stop, c);
-          });
+        // Add each of the colors to the gradient
+        areaColor.forEach((c: string, index: number) => {
+          const stop = stops * (index + 1);
+          gradient.addColorStop(stop, c);
+        });
 
-          // Set the gradient to the canvas fill
-          this.canvas.setFillStyle(gradient);
+        // Set the gradient to the canvas fill
+        this.canvas.setFillStyle(gradient);
 
-          // Fill using the gradient on the data path
-          this.canvas.fillPath(dataFill);
+        // Fill using the gradient on the data path
+        this.canvas.fillPath(dataFill);
       } else {
-          // If areaColor is not provided, use color.
-          this.canvas.fillPath(dataFill, areaColor || color);
+        // If areaColor is not provided, use color.
+        this.canvas.fillPath(dataFill, areaColor || color);
       }
     }
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ interface SparkLineProps {
   animationDuration?: number;
   includeZero?: boolean;
   areaOpacity?: number;
+  areaColor?: string | string[]
 }
 
 interface SparkLineState {
@@ -28,6 +29,10 @@ export class SparkLine extends React.Component<SparkLineProps, SparkLineState> {
     animationDuration: PropTypes.number,
     includeZero: PropTypes.bool,
     areaOpacity: PropTypes.number,
+    areaColor: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+    ]),
   };
 
   public static defaultProps: Partial<SparkLineProps> = {
@@ -117,7 +122,7 @@ export class SparkLine extends React.Component<SparkLineProps, SparkLineState> {
 
   private draw = () => {
     if (this.canvas) {
-      const { color, width, height, includeZero, areaOpacity } = this.props;
+      const { color, width, height, includeZero, areaOpacity, areaColor } = this.props;
 
       let { data } = this.props;
       let { transition } = this.state;
@@ -156,8 +161,32 @@ export class SparkLine extends React.Component<SparkLineProps, SparkLineState> {
         .beginPath()
         .strokePath(datas, color)
         .setOpacity(areaOpacity!)
-        .beginPath()
-        .fillPath(dataFill, color);
+        .beginPath();
+
+      // If areaColor is provided and it is an array, create a gradient
+      if (areaColor && Array.isArray(areaColor)) {
+          // Set the gradient to be from the top to the bottom
+          const gradient = this.canvas
+              .createLinearGradient(0, 0, 0, height);
+
+          // gradient.addColorStop() requires a number between 0 and 1 as the color stop
+          const stops = 1 / areaColor.length;
+
+          // Add each of the colors to the gradient
+          areaColor.forEach((c: string, index: number) => {
+              const stop = stops * (index + 1);
+              gradient.addColorStop(stop, c);
+          });
+
+          // Set the gradient to the canvas fill
+          this.canvas.setFillStyle(gradient);
+
+          // Fill using the gradient on the data path
+          this.canvas.fillPath(dataFill);
+      } else {
+          // If areaColor is not provided, use color.
+          this.canvas.fillPath(dataFill, areaColor || color);
+      }
     }
   }
 }

--- a/tests/__snapshots__/index.tsx.snap
+++ b/tests/__snapshots__/index.tsx.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SparkLine areaColor should accept a string 1`] = `
+<canvas
+  height={40}
+  style={
+    Object {
+      "height": 20,
+      "width": 80,
+    }
+  }
+  width={160}
+/>
+`;
+
+exports[`SparkLine areaColor should accept an array of strings 1`] = `
+<canvas
+  height={40}
+  style={
+    Object {
+      "height": 20,
+      "width": 80,
+    }
+  }
+  width={160}
+/>
+`;
+
+exports[`SparkLine areaColor should be optional 1`] = `
+<canvas
+  height={40}
+  style={
+    Object {
+      "height": 20,
+      "width": 80,
+    }
+  }
+  width={160}
+/>
+`;
+
 exports[`SparkLine should render a canvas with the provided width and height 1`] = `
 <canvas
   height={40}

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -16,4 +16,44 @@ describe('SparkLine', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  describe('areaColor', () => {
+    it('should be optional', () => {
+      const tree = renderer.create(
+          <SparkLine
+              width={80}
+              height={20}
+              data={[1, 2, 3]}
+              color="red"
+          />
+      );
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should accept a string', () => {
+      const tree = renderer.create(
+          <SparkLine
+              width={80}
+              height={20}
+              data={[1, 2, 3]}
+              color="red"
+              areaColor="red"
+          />
+      );
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should accept an array of strings', () => {
+      const tree = renderer.create(
+          <SparkLine
+              width={80}
+              height={20}
+              data={[1, 2, 3]}
+              color="red"
+              areaColor={['red', 'white']}
+          />
+      );
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
There are use cases where you might want the areaColor to be different to the stroke color. It would be nice for this to also be able to be a gradient. 

I've add a really simple top to bottom gradient using an areaColor array of strings.